### PR TITLE
add: macOS mod installation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,21 @@
 - [Lovely](https://github.com/ethangreen-dev/lovely-injector) injector -- Get it here: https://github.com/ethangreen-dev/lovely-injector/releases
 
 ## Installation
+
 1. Install [Lovely](https://github.com/ethangreen-dev/lovely-injector) and follow the manual installation instructions.
+
+### Windows
+
 2. Download the [latest release](https://github.com/OceanRamen/Brainstorm/releases/) of Brainstorm.
 3. Unzip the file, and place it in `.../%appdata%/balatro/mods` -- Make sure the Mod's directory name is 'Brainstorm' [^1]
 4. Reload the game to activate the mod.
+
+### Macos
+
+2. Go to your Balatro Mods dir `/Users/$USER/Library/Application Support/Balatro/Mods`.
+3. Clone the Brainstorm repo `git clone https://github.com/OceanRamen/Brainstorm.git`.
+4. Check that the new directory's name is "Brainstorm".
+5. Reload the game to activate the mod.
 
 ## Features
 ### Save-States


### PR DESCRIPTION
Hi !

I recently tried to install Brainstorm mod on my macOS software.
Unfortunately, I can't used the realeased version you give on your installation notice because dll files does not works on mac.
After several experiments, it appears that you just have to clone the source code into the right folder.
I added a little notice on how to install for macOS.

If you have any question you can reach me anytime.
If you have any better suggestion please feel free to tell me.

Thanks for your time.