### PR TITLE
feat(i18n): add zh_CN localization with vanilla term fallback and safe settings migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+plan

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.DS_Store
-plan

--- a/Brainstorm.lua
+++ b/Brainstorm.lua
@@ -3,6 +3,7 @@ function initBrainstorm()
 	local lovely = require("lovely")
 	local nativefs = require("nativefs")
 	assert(load(nativefs.read(lovely.mod_dir .. "/Brainstorm/Brainstorm_main.lua")))()
+	assert(load(nativefs.read(lovely.mod_dir .. "/Brainstorm/Brainstorm_i18n.lua")))()
 	assert(load(nativefs.read(lovely.mod_dir .. "/Brainstorm/Brainstorm_UI.lua")))()
 	assert(load(nativefs.read(lovely.mod_dir .. "/Brainstorm/Brainstorm_keyhandler.lua")))()
 	assert(load(nativefs.read(lovely.mod_dir .. "/Brainstorm/Brainstorm_reroll.lua")))()
@@ -10,9 +11,11 @@ function initBrainstorm()
 		local settings_file = STR_UNPACK(nativefs.read((lovely.mod_dir .. "/Brainstorm/settings.lua")))
 		if settings_file ~= nil then
 			Brainstorm.SETTINGS = settings_file
+			if Brainstorm.migrate_settings() then
+				nativefs.write(lovely.mod_dir .. "/Brainstorm/settings.lua", STR_PACK(Brainstorm.SETTINGS))
+			end
 		end
 	end
   _RELEASE_MODE = not Brainstorm.SETTINGS.debug_mode
 end
-
 

--- a/Brainstorm_UI.lua
+++ b/Brainstorm_UI.lua
@@ -1,60 +1,13 @@
 local lovely = require("lovely")
 local nativefs = require("nativefs")
 
-
-
-Brainstorm.SearchTagList = {
-	["None"]="",
-	["Uncommon Tag"]="tag_uncommon",
-	["Rare Tag"]="tag_rare",
-	["Holographic Tag"]="tag_holo",
-  ["Foil Tag"]="tag_foil",
-	["Polychrome Tag"]="tag_polychrome",
-	["Investment Tag"]="tag_investment",
-	["Voucher Tag"]="tag_voucher",
-	["Boss Tag"]="tag_boss",
-	["Charm Tag"]="tag_charm",
-	["Juggle Tag"]="tag_juggle",
-	["Double Tag"]="tag_double",
-	["Coupon Tag"]="tag_coupon",
-	["Economy Tag"]="tag_economy",
-	["Skip Tag"]="tag_skip",
-	["D6 Tag"]="tag_d_six",
-}
-
-Brainstorm.SearchPackList = {
-	["None"] = {},
-	["Arcana"] = {"p_arcana_normal_1","p_arcana_normal_2","p_arcana_normal_3","p_arcana_normal_4","p_arcana_jumbo_1","p_arcana_jumbo_2","p_arcana_mega_1", "p_arcana_mega_2"},
-	["Celestial"] = {"p_celestial_normal_1","p_celestial_normal_2","p_celestial_normal_3","p_celestial_normal_4","p_celestial_jumbo_1","p_celestial_jumbo_2","p_celestial_mega_1", "p_celestial_mega_2"},
-	["Standard"] = {"p_standard_normal_1","p_standard_normal_2","p_standard_normal_3","p_standard_normal_4","p_standard_jumbo_1","p_standard_jumbo_2","p_standard_mega_1", "p_standard_mega_2"},
-	["Buffoon"] = {"p_buffoon_normal_1","p_buffoon_normal_2","p_buffoon_jumbo_1","p_buffoon_mega_1"},
-	["Spectral"] = {"p_spectral_normal_1","p_spectral_normal_2","p_spectral_jumbo_1","p_spectral_mega_1"},
-	["Normal Arcana"] = {"p_arcana_normal_1","p_arcana_normal_2","p_arcana_normal_3","p_arcana_normal_4"},
-	["Jumbo Arcana"] = {"p_arcana_jumbo_1","p_arcana_jumbo_2"},
-	["Mega Arcana"] = {"p_arcana_mega_1", "p_arcana_mega_2"},
-	["Normal Celestial"] = {"p_celestial_normal_1","p_celestial_normal_2","p_celestial_normal_3","p_celestial_normal_4"},
-	["Jumbo Celestial"] = {"p_celestial_jumbo_1","p_celestial_jumbo_2"},
-	["Mega Celestial"] = {"p_celestial_mega_1", "p_celestial_mega_2"},
-	["Normal Standard"] = {"p_standard_normal_1","p_standard_normal_2","p_standard_normal_3","p_standard_normal_4"},
-	["Jumbo Standard"] = {"p_standard_jumbo_1","p_standard_jumbo_2"},
-	["Mega Standard"] = {"p_standard_mega_1", "p_standard_mega_2"},
-	["Normal Buffoon"] = {"p_buffoon_normal_1","p_buffoon_normal_2"},
-	["Jumbo Buffoon"] = {"p_buffoon_jumbo_1"},
-	["Mega Buffoon"] = {"p_buffoon_mega_1"},
-	["Normal Spectral"] = {"p_spectral_normal_1","p_spectral_normal_2"},
-	["Jumbo Spectral"] = {"p_spectral_jumbo_1"},
-	["Mega Spectral"] = {"p_spectral_mega_1"},
-}
 Brainstorm.seedsPerFrame = {
     ["500"] = 500,
     ["750"] = 750,
     ["1000"] = 1000,
 }
 
-local searchTagKeys = {"None", "Charm Tag", "Double Tag", "Uncommon Tag", "Rare Tag", "Holographic Tag", "Foil Tag", "Polychrome Tag", "Investment Tag", "Voucher Tag", "Boss Tag", "Juggle Tag", "Coupon Tag", "Economy Tag", "Skip Tag", "D6 Tag"}
-local searchPackKeys = {"None", "Arcana", "Celestial", "Standard", "Buffoon", "Spectral", "Normal Arcana", "Jumbo Arcana", "Mega Arcana", "Normal Celestial", "Jumbo Celestial", "Mega Celestial", "Normal Standard", "Jumbo Standard", "Mega Standard", "Normal Buffoon", "Jumbo Buffoon", "Mega Buffoon", "Normal Spectral", "Jumbo Spectral", "Mega Spectral"}
 local seedsPerFrame = {"500", "750", "1000"}
--- print(Brainstorm.FUNCS.inspect(searchTagKeys))
 
 Brainstorm.G_FUNCS_options_ref = G.FUNCS.options
 G.FUNCS.options = function(e)
@@ -63,8 +16,19 @@ end
 local ct = create_tabs
 function create_tabs(args)
 	if args and args.tab_h == 7.05 then
+		local searchTagLabels = Brainstorm.search_tag_labels()
+		local searchPackLabels = Brainstorm.search_pack_labels()
+		local currentTagOption = Brainstorm.option_index_by_key(Brainstorm.SearchTagOptions, Brainstorm.SETTINGS.autoreroll.searchTagKey)
+			or tonumber(Brainstorm.SETTINGS.autoreroll.searchTagID)
+			or 1
+		local currentPackOption = Brainstorm.option_index_by_key(Brainstorm.SearchPackOptions, Brainstorm.SETTINGS.autoreroll.searchPackKey)
+			or tonumber(Brainstorm.SETTINGS.autoreroll.searchPackID)
+			or 1
+		if currentTagOption < 1 or currentTagOption > #Brainstorm.SearchTagOptions then currentTagOption = 1 end
+		if currentPackOption < 1 or currentPackOption > #Brainstorm.SearchPackOptions then currentPackOption = 1 end
+
 		args.tabs[#args.tabs + 1] = {
-			label = "Brainstorm",
+			label = Brainstorm.t('ui.tab_name'),
 			tab_definition_function = function()
 				return {
 					n = G.UIT.ROOT,
@@ -73,42 +37,42 @@ function create_tabs(args)
 						padding = 0.05,
 						colour = G.C.CLEAR,
 					},
-					nodes = {
-						create_toggle({
-							label = "Debug Mode",
-							ref_table = Brainstorm.SETTINGS,
-							ref_value = "debug_mode",
+						nodes = {
+							create_toggle({
+								label = Brainstorm.t('ui.debug_mode'),
+								ref_table = Brainstorm.SETTINGS,
+								ref_value = "debug_mode",
 							callback = function(_set_toggle)
 								_RELEASE_MODE = not Brainstorm.SETTINGS.debug_mode
 								G.F_NO_ACHIEVEMENTS = Brainstorm.SETTINGS.debug_mode
 							end,
-						}),
-						create_option_cycle({
-							label = "AutoReroll Search Tag",
-							scale = 0.8,
-							w = 4,
-							options = searchTagKeys,
-							opt_callback = "change_search_tag",
-							current_option = Brainstorm.SETTINGS.autoreroll.searchTagID or 1,
-						}),
-						create_option_cycle({
-							label = "AutoReroll Search Pack",
-							scale = 0.8,
-							w = 4,
-							options = searchPackKeys,
-							opt_callback = "change_search_pack",
-							current_option = Brainstorm.SETTINGS.autoreroll.searchPackID or 1,
-						}),
-						create_option_cycle({
-							label = "Charm Tag/Arcana Pack: Number of Souls",
-							scale = 0.8,
-							w = 4,
-							options = {0,1,2},
-							opt_callback = "change_search_soul_count",
-							current_option = Brainstorm.SETTINGS.autoreroll.searchForSoul + 1 or 1,
-						}),
+							}),
+							create_option_cycle({
+								label = Brainstorm.t('ui.search_tag'),
+								scale = 0.8,
+								w = 4,
+								options = searchTagLabels,
+								opt_callback = "change_search_tag",
+								current_option = currentTagOption,
+							}),
+							create_option_cycle({
+								label = Brainstorm.t('ui.search_pack'),
+								scale = 0.8,
+								w = 4,
+								options = searchPackLabels,
+								opt_callback = "change_search_pack",
+								current_option = currentPackOption,
+							}),
+							create_option_cycle({
+								label = Brainstorm.t('ui.soul_count'),
+								scale = 0.8,
+								w = 4,
+								options = {0,1,2},
+								opt_callback = "change_search_soul_count",
+								current_option = (Brainstorm.SETTINGS.autoreroll.searchForSoul or 0) + 1,
+							}),
                         create_option_cycle({
-							label = "Rerolls per Frame",
+							label = Brainstorm.t('ui.rerolls_per_frame'),
 							scale = 0.8,
 							w = 4,
 							options = seedsPerFrame,

--- a/Brainstorm_i18n.lua
+++ b/Brainstorm_i18n.lua
@@ -16,6 +16,19 @@ Brainstorm.I18N = {
       },
       option = {
         none = 'None',
+        kind = {
+          arcana = 'Arcana',
+          celestial = 'Celestial',
+          standard = 'Standard',
+          buffoon = 'Buffoon',
+          spectral = 'Spectral',
+        },
+        size = {
+          normal = 'Normal',
+          jumbo = 'Jumbo',
+          mega = 'Mega',
+        },
+        pack_template = '{size} {kind} Pack',
         pack = {
           arcana_all = 'Arcana Pack (All)',
           celestial_all = 'Celestial Pack (All)',
@@ -27,7 +40,7 @@ Brainstorm.I18N = {
     },
     ['zh_CN'] = {
       ui = {
-        tab_name = 'Brainstorm',
+        tab_name = '头脑风暴',
         debug_mode = '调试模式',
         search_tag = '自动重掷：目标标签',
         search_pack = '自动重掷：目标补充包',
@@ -41,6 +54,19 @@ Brainstorm.I18N = {
       },
       option = {
         none = '无',
+        kind = {
+          arcana = '秘术',
+          celestial = '天体',
+          standard = '标准',
+          buffoon = '小丑',
+          spectral = '幻灵',
+        },
+        size = {
+          normal = '普通',
+          jumbo = '巨型',
+          mega = '超级',
+        },
+        pack_template = '{size}{kind}包',
         pack = {
           arcana_all = '秘术包（全部）',
           celestial_all = '天体包（全部）',
@@ -156,8 +182,29 @@ end
 
 local function booster_name(key)
   if not key or key == '' then return nil end
-  local base_key = string.gsub(key, '_%d+$', '')
-  return game_name('Booster', base_key) or game_name('Booster', key)
+
+  local normalized_key = string.lower(key)
+  local base_key = string.gsub(normalized_key, '_%d+$', '')
+
+  local localized = game_name('Booster', base_key)
+    or game_name('Booster', normalized_key)
+    or game_name('Booster', key)
+  if localized then return localized end
+
+  local kind, size = string.match(normalized_key, '^p_([a-z]+)_([a-z]+)_%d+$')
+  if not kind or not size then
+    kind, size = string.match(base_key, '^p_([a-z]+)_([a-z]+)$')
+  end
+
+  if kind and size then
+    local kind_label = Brainstorm.t('option.kind.' .. kind)
+    local size_label = Brainstorm.t('option.size.' .. size)
+    if kind_label ~= ('option.kind.' .. kind) and size_label ~= ('option.size.' .. size) then
+      return Brainstorm.t('option.pack_template', { size = size_label, kind = kind_label })
+    end
+  end
+
+  return key
 end
 
 function Brainstorm.search_tag_labels()

--- a/Brainstorm_i18n.lua
+++ b/Brainstorm_i18n.lua
@@ -1,0 +1,317 @@
+Brainstorm.I18N = {
+  mod = {
+    ['en-us'] = {
+      ui = {
+        tab_name = 'Brainstorm',
+        debug_mode = 'Debug Mode',
+        search_tag = 'AutoReroll Search Tag',
+        search_pack = 'AutoReroll Search Pack',
+        soul_count = 'Charm Tag/Arcana Pack: Number of Souls',
+        rerolls_per_frame = 'Rerolls per Frame',
+      },
+      toast = {
+        rerolling = 'Rerolling...',
+        saved_slot = 'Saved state to slot [{k}]',
+        loaded_slot = 'Loaded save from slot [{k}]',
+      },
+      option = {
+        none = 'None',
+        pack = {
+          arcana_all = 'Arcana Pack (All)',
+          celestial_all = 'Celestial Pack (All)',
+          standard_all = 'Standard Pack (All)',
+          buffoon_all = 'Buffoon Pack (All)',
+          spectral_all = 'Spectral Pack (All)',
+        },
+      },
+    },
+    ['zh_CN'] = {
+      ui = {
+        tab_name = 'Brainstorm',
+        debug_mode = '调试模式',
+        search_tag = '自动重掷：目标标签',
+        search_pack = '自动重掷：目标补充包',
+        soul_count = '魅力标签/秘术包：灵魂数量',
+        rerolls_per_frame = '每帧重掷次数',
+      },
+      toast = {
+        rerolling = '重掷中…',
+        saved_slot = '已保存到槽位 [{k}]',
+        loaded_slot = '已读取槽位 [{k}] 存档',
+      },
+      option = {
+        none = '无',
+        pack = {
+          arcana_all = '秘术包（全部）',
+          celestial_all = '天体包（全部）',
+          standard_all = '标准包（全部）',
+          buffoon_all = '小丑包（全部）',
+          spectral_all = '幻灵包（全部）',
+        },
+      },
+    },
+  },
+}
+
+Brainstorm.SearchTagOptions = {
+  { key = 'none', tag_key = '' },
+  { key = 'tag_uncommon', tag_key = 'tag_uncommon' },
+  { key = 'tag_rare', tag_key = 'tag_rare' },
+  { key = 'tag_holo', tag_key = 'tag_holo' },
+  { key = 'tag_foil', tag_key = 'tag_foil' },
+  { key = 'tag_polychrome', tag_key = 'tag_polychrome' },
+  { key = 'tag_investment', tag_key = 'tag_investment' },
+  { key = 'tag_voucher', tag_key = 'tag_voucher' },
+  { key = 'tag_boss', tag_key = 'tag_boss' },
+  { key = 'tag_charm', tag_key = 'tag_charm' },
+  { key = 'tag_juggle', tag_key = 'tag_juggle' },
+  { key = 'tag_double', tag_key = 'tag_double' },
+  { key = 'tag_coupon', tag_key = 'tag_coupon' },
+  { key = 'tag_economy', tag_key = 'tag_economy' },
+  { key = 'tag_skip', tag_key = 'tag_skip' },
+  { key = 'tag_d_six', tag_key = 'tag_d_six' },
+}
+
+Brainstorm.SearchPackOptions = {
+  { key = 'none', packs = {} },
+  {
+    key = 'arcana_all',
+    packs = { 'p_arcana_normal_1', 'p_arcana_normal_2', 'p_arcana_normal_3', 'p_arcana_normal_4', 'p_arcana_jumbo_1', 'p_arcana_jumbo_2', 'p_arcana_mega_1', 'p_arcana_mega_2' },
+    custom_label = 'option.pack.arcana_all',
+  },
+  {
+    key = 'celestial_all',
+    packs = { 'p_celestial_normal_1', 'p_celestial_normal_2', 'p_celestial_normal_3', 'p_celestial_normal_4', 'p_celestial_jumbo_1', 'p_celestial_jumbo_2', 'p_celestial_mega_1', 'p_celestial_mega_2' },
+    custom_label = 'option.pack.celestial_all',
+  },
+  {
+    key = 'standard_all',
+    packs = { 'p_standard_normal_1', 'p_standard_normal_2', 'p_standard_normal_3', 'p_standard_normal_4', 'p_standard_jumbo_1', 'p_standard_jumbo_2', 'p_standard_mega_1', 'p_standard_mega_2' },
+    custom_label = 'option.pack.standard_all',
+  },
+  {
+    key = 'buffoon_all',
+    packs = { 'p_buffoon_normal_1', 'p_buffoon_normal_2', 'p_buffoon_jumbo_1', 'p_buffoon_mega_1' },
+    custom_label = 'option.pack.buffoon_all',
+  },
+  {
+    key = 'spectral_all',
+    packs = { 'p_spectral_normal_1', 'p_spectral_normal_2', 'p_spectral_jumbo_1', 'p_spectral_mega_1' },
+    custom_label = 'option.pack.spectral_all',
+  },
+  { key = 'normal_arcana', packs = { 'p_arcana_normal_1', 'p_arcana_normal_2', 'p_arcana_normal_3', 'p_arcana_normal_4' }, booster_key = 'p_arcana_normal_1' },
+  { key = 'jumbo_arcana', packs = { 'p_arcana_jumbo_1', 'p_arcana_jumbo_2' }, booster_key = 'p_arcana_jumbo_1' },
+  { key = 'mega_arcana', packs = { 'p_arcana_mega_1', 'p_arcana_mega_2' }, booster_key = 'p_arcana_mega_1' },
+  { key = 'normal_celestial', packs = { 'p_celestial_normal_1', 'p_celestial_normal_2', 'p_celestial_normal_3', 'p_celestial_normal_4' }, booster_key = 'p_celestial_normal_1' },
+  { key = 'jumbo_celestial', packs = { 'p_celestial_jumbo_1', 'p_celestial_jumbo_2' }, booster_key = 'p_celestial_jumbo_1' },
+  { key = 'mega_celestial', packs = { 'p_celestial_mega_1', 'p_celestial_mega_2' }, booster_key = 'p_celestial_mega_1' },
+  { key = 'normal_standard', packs = { 'p_standard_normal_1', 'p_standard_normal_2', 'p_standard_normal_3', 'p_standard_normal_4' }, booster_key = 'p_standard_normal_1' },
+  { key = 'jumbo_standard', packs = { 'p_standard_jumbo_1', 'p_standard_jumbo_2' }, booster_key = 'p_standard_jumbo_1' },
+  { key = 'mega_standard', packs = { 'p_standard_mega_1', 'p_standard_mega_2' }, booster_key = 'p_standard_mega_1' },
+  { key = 'normal_buffoon', packs = { 'p_buffoon_normal_1', 'p_buffoon_normal_2' }, booster_key = 'p_buffoon_normal_1' },
+  { key = 'jumbo_buffoon', packs = { 'p_buffoon_jumbo_1' }, booster_key = 'p_buffoon_jumbo_1' },
+  { key = 'mega_buffoon', packs = { 'p_buffoon_mega_1' }, booster_key = 'p_buffoon_mega_1' },
+  { key = 'normal_spectral', packs = { 'p_spectral_normal_1', 'p_spectral_normal_2' }, booster_key = 'p_spectral_normal_1' },
+  { key = 'jumbo_spectral', packs = { 'p_spectral_jumbo_1' }, booster_key = 'p_spectral_jumbo_1' },
+  { key = 'mega_spectral', packs = { 'p_spectral_mega_1' }, booster_key = 'p_spectral_mega_1' },
+}
+
+local function get_lang_key()
+  if G and G.SETTINGS and G.SETTINGS.language and Brainstorm.I18N.mod[G.SETTINGS.language] then
+    return G.SETTINGS.language
+  end
+  return 'en-us'
+end
+
+local function get_by_path(root, path)
+  local node = root
+  for part in string.gmatch(path, '[^.]+') do
+    if type(node) ~= 'table' then return nil end
+    node = node[part]
+    if node == nil then return nil end
+  end
+  return node
+end
+
+function Brainstorm.t(key, vars)
+  local lang = get_lang_key()
+  local value = get_by_path(Brainstorm.I18N.mod[lang], key) or get_by_path(Brainstorm.I18N.mod['en-us'], key) or key
+  if type(value) ~= 'string' then return key end
+  if not vars then return value end
+
+  return (value:gsub('{([%w_]+)}', function(name)
+    local replacement = vars[name]
+    return replacement ~= nil and tostring(replacement) or '{' .. name .. '}'
+  end))
+end
+
+local function game_name(set_name, key)
+  if not key or key == '' then return nil end
+  local ok, result = pcall(function()
+    return localize({ type = 'name_text', set = set_name, key = key })
+  end)
+  if ok and result and result ~= 'ERROR' then return result end
+  return nil
+end
+
+local function booster_name(key)
+  if not key or key == '' then return nil end
+  local base_key = string.gsub(key, '_%d+$', '')
+  return game_name('Booster', base_key) or game_name('Booster', key)
+end
+
+function Brainstorm.search_tag_labels()
+  local labels = {}
+  for _, option in ipairs(Brainstorm.SearchTagOptions) do
+    if option.tag_key == '' then
+      labels[#labels + 1] = Brainstorm.t('option.none')
+    else
+      labels[#labels + 1] = game_name('Tag', option.tag_key) or option.tag_key
+    end
+  end
+  return labels
+end
+
+function Brainstorm.search_pack_labels()
+  local labels = {}
+  for _, option in ipairs(Brainstorm.SearchPackOptions) do
+    if option.key == 'none' then
+      labels[#labels + 1] = Brainstorm.t('option.none')
+    elseif option.custom_label then
+      labels[#labels + 1] = Brainstorm.t(option.custom_label)
+    elseif option.booster_key then
+      labels[#labels + 1] = booster_name(option.booster_key) or option.booster_key
+    else
+      labels[#labels + 1] = option.key
+    end
+  end
+  return labels
+end
+
+function Brainstorm.option_index_by_key(options, key)
+  if not key then return nil end
+  for i, option in ipairs(options) do
+    if option.key == key then return i end
+  end
+  return nil
+end
+
+function Brainstorm.option_index_by_tag_key(tag_key)
+  if not tag_key then return nil end
+  for i, option in ipairs(Brainstorm.SearchTagOptions) do
+    if option.tag_key == tag_key then return i end
+  end
+  return nil
+end
+
+function Brainstorm.option_index_by_packs(pack_list)
+  if type(pack_list) ~= 'table' then return nil end
+  for i, option in ipairs(Brainstorm.SearchPackOptions) do
+    local expected = option.packs
+    if #pack_list == #expected then
+      local same = true
+      for p = 1, #expected do
+        if pack_list[p] ~= expected[p] then
+          same = false
+          break
+        end
+      end
+      if same then return i end
+    end
+  end
+  return nil
+end
+
+function Brainstorm.migrate_settings()
+  local settings = Brainstorm.SETTINGS
+  if not settings then return false end
+  settings.autoreroll = settings.autoreroll or {}
+  local ar = settings.autoreroll
+  local changed = false
+
+  -- Keep legacy behavior stable: old config stored searchTag as semantic key.
+  local tag_index = Brainstorm.option_index_by_key(Brainstorm.SearchTagOptions, ar.searchTagKey)
+    or Brainstorm.option_index_by_tag_key(ar.searchTag)
+
+  if not tag_index and ar.searchTagID then
+    local legacy_tag_order = {
+      'none',
+      'tag_charm',
+      'tag_double',
+      'tag_uncommon',
+      'tag_rare',
+      'tag_holo',
+      'tag_foil',
+      'tag_polychrome',
+      'tag_investment',
+      'tag_voucher',
+      'tag_boss',
+      'tag_juggle',
+      'tag_coupon',
+      'tag_economy',
+      'tag_skip',
+      'tag_d_six',
+    }
+    local legacy_key = legacy_tag_order[tonumber(ar.searchTagID)]
+    if legacy_key and legacy_key ~= 'none' then
+      tag_index = Brainstorm.option_index_by_tag_key(legacy_key)
+    elseif legacy_key == 'none' then
+      tag_index = Brainstorm.option_index_by_key(Brainstorm.SearchTagOptions, 'none')
+    end
+  end
+
+  if not tag_index then
+    tag_index = 1
+  end
+
+  local selected_tag_key = Brainstorm.SearchTagOptions[tag_index].key
+  if ar.searchTagKey ~= selected_tag_key then
+    ar.searchTagKey = selected_tag_key
+    changed = true
+  end
+
+  if ar.searchTagID ~= tag_index then
+    ar.searchTagID = tag_index
+    changed = true
+  end
+
+  local tag_value = Brainstorm.SearchTagOptions[tag_index].tag_key
+  if ar.searchTag ~= tag_value then
+    ar.searchTag = tag_value
+    changed = true
+  end
+
+  local pack_index = Brainstorm.option_index_by_key(Brainstorm.SearchPackOptions, ar.searchPackKey)
+    or Brainstorm.option_index_by_packs(ar.searchPack)
+  if not pack_index then
+    pack_index = tonumber(ar.searchPackID) or 1
+    if pack_index < 1 or pack_index > #Brainstorm.SearchPackOptions then pack_index = 1 end
+    changed = true
+  end
+
+  if ar.searchPackKey ~= Brainstorm.SearchPackOptions[pack_index].key then
+    ar.searchPackKey = Brainstorm.SearchPackOptions[pack_index].key
+    changed = true
+  end
+
+  if ar.searchPackID ~= pack_index then
+    ar.searchPackID = pack_index
+    changed = true
+  end
+
+  local expected_packs = Brainstorm.SearchPackOptions[pack_index].packs
+  if type(ar.searchPack) ~= 'table' or #ar.searchPack ~= #expected_packs then
+    ar.searchPack = expected_packs
+    changed = true
+  else
+    for i = 1, #expected_packs do
+      if ar.searchPack[i] ~= expected_packs[i] then
+        ar.searchPack = expected_packs
+        changed = true
+        break
+      end
+    end
+  end
+
+  return changed
+end

--- a/Brainstorm_keyhandler.lua
+++ b/Brainstorm_keyhandler.lua
@@ -12,7 +12,7 @@ function Brainstorm.key_press_update(key)
 		if key == k and love.keyboard.isDown(Brainstorm.SETTINGS.keybinds.saveState) then
 			if G.STAGE == G.STAGES.RUN then
 				compress_and_save(G.SETTINGS.profile .. "/" .. "saveState" .. k .. ".jkr", G.ARGS.save_run)
-				saveManagerAlert("Saved state to slot [" .. k .. "]")
+				saveManagerAlert(Brainstorm.t('toast.saved_slot', { k = k }))
 			end
 		end
 		--  LoadState
@@ -25,7 +25,7 @@ function Brainstorm.key_press_update(key)
 			G:start_run({
 				savetext = G.SAVED_GAME,
 			})
-			saveManagerAlert("Loaded save from slot [" .. k .. "]")
+			saveManagerAlert(Brainstorm.t('toast.loaded_slot', { k = k }))
 		end
   end
 	--  FastReroll

--- a/Brainstorm_main.lua
+++ b/Brainstorm_main.lua
@@ -22,7 +22,7 @@ function Brainstorm.update(dt)
 		Brainstorm.AUTOREROLL.autoRerollFrames = Brainstorm.AUTOREROLL.autoRerollFrames + 1
 		if Brainstorm.AUTOREROLL.autoRerollFrames == 20 then
 			Brainstorm.AUTOREROLL.rerollText = Brainstorm.attention_text({
-				scale = 1.4, text = "Rerolling...", align = 'cm', offset = {x = 0,y = -3.5},major = G.STAGE == G.STAGES.RUN and G.play or G.title_top
+				scale = 1.4, text = Brainstorm.t('toast.rerolling'), align = 'cm', offset = {x = 0,y = -3.5},major = G.STAGE == G.STAGES.RUN and G.play or G.title_top
 			})
 		end
 	end

--- a/Brainstorm_reroll.lua
+++ b/Brainstorm_reroll.lua
@@ -4,14 +4,18 @@ local nativefs = require("nativefs")
 Brainstorm.AUTOREROLL = {}
 
 G.FUNCS.change_search_tag = function(x)
+	local option = Brainstorm.SearchTagOptions[x.to_key] or Brainstorm.SearchTagOptions[1]
 	Brainstorm.SETTINGS.autoreroll.searchTagID = x.to_key
-	Brainstorm.SETTINGS.autoreroll.searchTag = Brainstorm.SearchTagList[x.to_val]
+	Brainstorm.SETTINGS.autoreroll.searchTagKey = option.key
+	Brainstorm.SETTINGS.autoreroll.searchTag = option.tag_key
 	nativefs.write(lovely.mod_dir .. "/Brainstorm/settings.lua", STR_PACK(Brainstorm.SETTINGS))
 end
 
 G.FUNCS.change_search_pack = function(x)
+	local option = Brainstorm.SearchPackOptions[x.to_key] or Brainstorm.SearchPackOptions[1]
 	Brainstorm.SETTINGS.autoreroll.searchPackID = x.to_key
-	Brainstorm.SETTINGS.autoreroll.searchPack = Brainstorm.SearchPackList[x.to_val]
+	Brainstorm.SETTINGS.autoreroll.searchPackKey = option.key
+	Brainstorm.SETTINGS.autoreroll.searchPack = option.packs
 	nativefs.write(lovely.mod_dir .. "/Brainstorm/settings.lua", STR_PACK(Brainstorm.SETTINGS))
 end
 

--- a/README.md
+++ b/README.md
@@ -36,3 +36,6 @@ Brainstorm allows for super-fast rerolling through the use of an in-game key bin
 Brainstorm can automatically reroll for parameters as specified by the user.
 You can edit the Auto-Reroll parameters in the Brainstorm in-game settings page.
 > To Auto-Reroll:	Press `Ctrl + a`
+
+### I18n Support
+Added i18n support (Currently supports English and Simplified Chinese, easily extensible for other languages).


### PR DESCRIPTION
 Summary
Introduce i18n support for Brainstorm (English + Simplified Chinese), migrate AutoReroll options to stable keys, and align Tag/Booster naming with Balatro localization.
 Details
- Added `Brainstorm_i18n.lua` with `Brainstorm.t(...)`, locale dictionaries, and settings migration.
- Replaced hard-coded UI/toast strings with translation keys.
- AutoReroll settings now persist stable keys (`searchTagKey`, `searchPackKey`) for language-safe behavior.
- Tag/Booster labels now use Balatro `localize(...)` for terminology consistency.
 Compatibility
Backward-compatible with existing settings; migration is designed to preserve legacy selection semantics.
 Test
- [✅ ] Verify English/Chinese UI text switching
- [ ✅] Verify Tag/Pack labels match base game terms
- [ ✅] Verify old settings are preserved after migration
- [ ✅] Verify reroll/save/load behavior unchanged